### PR TITLE
Cleanup copyrights

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,6 @@
 
 © 2020 Ilya Mateyko
 
-© 2019 Frédéric Guillot
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 # © 2020 Ilya Mateyko. All rights reserved.
-# © 2019 Frédéric Guillot. All rights reserved.
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE.md file.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/page/page.go
+++ b/internal/page/page.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/scaffold/create.go
+++ b/internal/scaffold/create.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/scaffold/doc.go
+++ b/internal/scaffold/doc.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/scaffold/files.go
+++ b/internal/scaffold/files.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/scaffold/generate.go
+++ b/internal/scaffold/generate.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 
@@ -23,7 +22,6 @@ import (
 const name = "files.go"
 
 var tpl = template.Must(template.New("").Parse(`// © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/site/site.go
+++ b/internal/site/site.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/main.go
+++ b/main.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/pkg/fileutil/fileutil.go
+++ b/pkg/fileutil/fileutil.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 

--- a/pkg/fileutil/fileutil_test.go
+++ b/pkg/fileutil/fileutil_test.go
@@ -1,5 +1,4 @@
 // © 2020 Ilya Mateyko. All rights reserved.
-// © 2019 Frédéric Guillot. All rights reserved.
 // Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.md file.
 


### PR DESCRIPTION
`gen` no longer contains any plop code.